### PR TITLE
rename used to redeemed, unused to not-redeemed

### DIFF
--- a/app/models/token.rb
+++ b/app/models/token.rb
@@ -9,8 +9,8 @@ class Token < ApplicationRecord
 
   scope :untouched, -> { where(touched_at: nil) }
 
-  def unused?
-    nominee.nil?
+  def redeemed?
+    nominee.present?
   end
 
   def to_param

--- a/app/policies/token_policy.rb
+++ b/app/policies/token_policy.rb
@@ -1,5 +1,5 @@
 class TokenPolicy < ApplicationPolicy
   def legit?
-    record.poll.started? && record.unused? && user.nil?
+    record.poll.started? && !record.redeemed? && user.nil?
   end
 end

--- a/test/fixtures/tokens.yml
+++ b/test/fixtures/tokens.yml
@@ -6,12 +6,12 @@ best_actor_token_1:
   value: 'BEST-ACTOR-TOKEN-1'
   poll: best_actor_published
 
-best_singer_token_unused:
-  value: 'BEST-SINGER-TOKEN-UNUSED'
+best_singer_token_not_redeemed:
+  value: 'BEST-SINGER-TOKEN-NOT-REDEEMED'
   poll: best_singer_started
 
-best_singer_token_used:
-  value: 'BEST-SINGER-TOKEN-USED'
+best_singer_token_redeemed:
+  value: 'BEST-SINGER-TOKEN-REDEEMED'
   poll: best_singer_started
   nominee: best_singer_adele
 

--- a/test/forms/poll_voting_form_test.rb
+++ b/test/forms/poll_voting_form_test.rb
@@ -4,7 +4,7 @@ class PollVotingFormTest < ActiveSupport::TestCase
   attr_reader :token, :nominee
 
   setup do
-    @token = tokens(:best_singer_token_unused)
+    @token = tokens(:best_singer_token_not_redeemed)
     @nominee = nominees(:best_singer_adele)
   end
 

--- a/test/system/poll_vote_test.rb
+++ b/test/system/poll_vote_test.rb
@@ -1,17 +1,17 @@
 require 'application_system_test_case'
 
 class PollsVoteTest < ApplicationSystemTestCase
-  attr_reader :started_poll, :started_poll_token_unused
+  attr_reader :started_poll, :started_poll_token_not_redeemed
 
   setup do
     @started_poll = polls(:best_singer_started)
-    @started_poll_token_unused = tokens(:best_singer_token_unused)
+    @started_poll_token_not_redeemed = tokens(:best_singer_token_not_redeemed)
   end
 
   test 'guest votes for a started poll using valid token' do
     sign_out
 
-    visit poll_vote_path(started_poll, token_value: started_poll_token_unused.value)
+    visit poll_vote_path(started_poll, token_value: started_poll_token_not_redeemed.value)
 
     assert_selector 'h1', text: 'Cast your vote'
 
@@ -32,7 +32,7 @@ class PollsVoteTest < ApplicationSystemTestCase
   test 'signed in user cannot vote' do
     sign_in_as(:julia_roberts)
 
-    visit poll_vote_path(started_poll, token_value: started_poll_token_unused.value)
+    visit poll_vote_path(started_poll, token_value: started_poll_token_not_redeemed.value)
 
     assert_selector 'h1', text: 'Best singer'
   end


### PR DESCRIPTION
This is a pre-step for an upcoming naming refactoring for Tokens

Later we’re going to use the words “used” / “unused” for “touched” / “untouched” tokens.