### PR TITLE
Show archived on poll show

### DIFF
--- a/app/controllers/polls_controller.rb
+++ b/app/controllers/polls_controller.rb
@@ -1,6 +1,6 @@
 class PollsController < ApplicationController
   def index
-    @polls = policy_scope(Poll).ordered
+    @polls = policy_scope(Poll).not_archived.ordered
   end
 
   def show

--- a/app/javascript/src/application.css
+++ b/app/javascript/src/application.css
@@ -78,13 +78,13 @@ input[type=submit]:hover {
   @apply my-16 py-10 text-gray-300 text-center;
 }
 
-.poll-state-draft           { @apply text-apollo-teal-500 bg-apollo-teal-100 border border-apollo-teal-100 shadow-lg; }
+.poll-state-drafted           { @apply text-apollo-teal-500 bg-apollo-teal-100 border border-apollo-teal-100 shadow-lg; }
 .poll-state-published       { @apply text-apollo-violet-500 bg-apollo-violet-100 border border-apollo-violet-100 shadow-lg; }
 .poll-state-started         { @apply text-apollo-green-500 bg-apollo-green-100 border border-apollo-green-100 shadow-lg; }
 .poll-state-closed          { @apply text-apollo-pink-500 bg-apollo-pink-100 border border-apollo-pink-100 shadow-lg; }
 .poll-state-archived        { @apply text-orange-600 bg-orange-100 border border-orange-100 shadow-lg; }
 
-.text-poll-state-draft      { @apply text-apollo-teal-500; }
+.text-poll-state-drafted      { @apply text-apollo-teal-500; }
 .text-poll-state-published  { @apply text-apollo-violet-500; }
 .text-poll-state-started    { @apply text-apollo-green-500; }
 .text-poll-state-closed     { @apply text-apollo-pink-500; }

--- a/app/models/concerns/statable.rb
+++ b/app/models/concerns/statable.rb
@@ -15,6 +15,7 @@ module Statable
   # rubocop:disable Metrics/BlockLength
   included do
     scope :not_drafted, -> { where.not(published_at: nil) }
+    scope :not_archived, -> { where(archived_at: nil) }
     scope :not_deleted, -> { where(deleted_at: nil) }
 
     validate :verified_user, unless: :drafted?

--- a/app/models/concerns/statable.rb
+++ b/app/models/concerns/statable.rb
@@ -2,7 +2,7 @@ module Statable
   extend ActiveSupport::Concern
 
   ALLOWED_TRANSITIONS = {
-    draft: %i[deleted published],
+    drafted: %i[deleted published],
     published: %i[deleted started],
     started: %i[closed],
     closed: %i[archived],
@@ -10,14 +10,14 @@ module Statable
     deleted: []
   }.freeze
 
-  INITIAL_STATE = :draft
+  INITIAL_STATE = :drafted
 
   # rubocop:disable Metrics/BlockLength
   included do
-    scope :not_draft, -> { where.not(published_at: nil) }
+    scope :not_drafted, -> { where.not(published_at: nil) }
     scope :not_deleted, -> { where(deleted_at: nil) }
 
-    validate :verified_user, unless: :draft?
+    validate :verified_user, unless: :drafted?
 
     def state
       return :deleted if deleted?
@@ -30,7 +30,7 @@ module Statable
     end
 
     def next_state
-      return :published if draft?
+      return :published if drafted?
       return :started if published?
       return :closed if started?
       return :archived if closed?
@@ -67,7 +67,7 @@ module Statable
 
     # state calculations
 
-    def draft?
+    def drafted?
       return false if deleted?
 
       published_at.nil?
@@ -102,7 +102,7 @@ module Statable
     # abilities
 
     def editable?
-      draft? || published?
+      drafted? || published?
     end
 
     def deletable?

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -13,12 +13,7 @@ class Poll < ApplicationRecord
   has_many :tokens, dependent: :destroy
 
   scope :ordered, -> { order(created_at: :desc) }
-  scope :listed, -> { timestamp_between(:published_at, :archived_at).not_deleted.not_drafted }
-  scope :timestamp_between, ->(from_column, until_column, timestamp = Time.zone.now) {
-    where(":timestamp BETWEEN COALESCE(#{from_column}, '1000-01-01')
-                          AND COALESCE(#{until_column}, '9999-12-31')",
-          timestamp: timestamp)
-  }
+  scope :listed, -> { not_deleted.not_drafted }
   scope :of_user, ->(user) { where(user: user) }
 
   def to_param

--- a/app/models/poll.rb
+++ b/app/models/poll.rb
@@ -13,7 +13,7 @@ class Poll < ApplicationRecord
   has_many :tokens, dependent: :destroy
 
   scope :ordered, -> { order(created_at: :desc) }
-  scope :listed, -> { timestamp_between(:published_at, :archived_at).not_deleted.not_draft }
+  scope :listed, -> { timestamp_between(:published_at, :archived_at).not_deleted.not_drafted }
   scope :timestamp_between, ->(from_column, until_column, timestamp = Time.zone.now) {
     where(":timestamp BETWEEN COALESCE(#{from_column}, '1000-01-01')
                           AND COALESCE(#{until_column}, '9999-12-31')",

--- a/test/controllers/admin/polls/nominees_controller_test.rb
+++ b/test/controllers/admin/polls/nominees_controller_test.rb
@@ -94,7 +94,7 @@ class Admin::Polls::NomineesControllerTest < ActionDispatch::IntegrationTest
     assert_all_exceptions(published_poll, Pundit::NotAuthorizedError)
     assert_all_exceptions(started_poll, Pundit::NotAuthorizedError)
     assert_all_exceptions(closed_poll, Pundit::NotAuthorizedError)
-    assert_all_exceptions(archived_poll, ActiveRecord::RecordNotFound)
+    assert_all_exceptions(archived_poll, Pundit::NotAuthorizedError)
     assert_all_exceptions(deleted_poll, ActiveRecord::RecordNotFound)
   end
 

--- a/test/controllers/admin/polls/state_changes_controller_test.rb
+++ b/test/controllers/admin/polls/state_changes_controller_test.rb
@@ -1,18 +1,18 @@
 require 'test_helper'
 
 class Admin::Polls::StateChangesControllerTest < ActionDispatch::IntegrationTest
-  attr_reader :draft_poll, :published_poll, :started_poll, :closed_poll
+  attr_reader :drafted_poll, :published_poll, :started_poll, :closed_poll
 
   setup do
-    @draft_poll = polls(:best_actress_draft)
+    @drafted_poll = polls(:best_actress_drafted)
     @published_poll = polls(:best_actor_published)
     @started_poll = polls(:best_singer_started)
     @closed_poll = polls(:best_movie_closed)
   end
 
-  test 'publish draft' do
+  test 'publish drafted' do
     sign_in_as(:julia_roberts)
-    assert_changes_to_state draft_poll, :published
+    assert_changes_to_state drafted_poll, :published
   end
 
   test 'start published' do
@@ -30,9 +30,9 @@ class Admin::Polls::StateChangesControllerTest < ActionDispatch::IntegrationTest
     assert_changes_to_state closed_poll, :archived
   end
 
-  test 'delete draft' do
+  test 'delete drafted' do
     sign_in_as(:julia_roberts)
-    assert_changes_to_state draft_poll, :deleted
+    assert_changes_to_state drafted_poll, :deleted
   end
 
   test 'delete published' do

--- a/test/controllers/admin/polls/tokens_controller_test.rb
+++ b/test/controllers/admin/polls/tokens_controller_test.rb
@@ -71,7 +71,7 @@ class Admin::Polls::TokensControllerTest < ActionDispatch::IntegrationTest
     assert_all_exceptions(published_poll, Pundit::NotAuthorizedError)
     assert_all_exceptions(started_poll, Pundit::NotAuthorizedError)
     assert_all_exceptions(closed_poll, Pundit::NotAuthorizedError)
-    assert_all_exceptions(archived_poll, ActiveRecord::RecordNotFound)
+    assert_all_exceptions(archived_poll, Pundit::NotAuthorizedError)
     assert_all_exceptions(deleted_poll, ActiveRecord::RecordNotFound)
   end
 

--- a/test/controllers/admin/polls_controller_test.rb
+++ b/test/controllers/admin/polls_controller_test.rb
@@ -81,7 +81,7 @@ class Admin::PollsControllerTest < ActionDispatch::IntegrationTest
     assert_all_exceptions(published_poll, Pundit::NotAuthorizedError)
     assert_all_exceptions(started_poll, Pundit::NotAuthorizedError)
     assert_all_exceptions(closed_poll, Pundit::NotAuthorizedError)
-    assert_all_exceptions(archived_poll, ActiveRecord::RecordNotFound)
+    assert_all_exceptions(archived_poll, Pundit::NotAuthorizedError)
     assert_all_exceptions(deleted_poll, ActiveRecord::RecordNotFound)
   end
 

--- a/test/controllers/admin/polls_controller_test.rb
+++ b/test/controllers/admin/polls_controller_test.rb
@@ -1,10 +1,10 @@
 require 'test_helper'
 
 class Admin::PollsControllerTest < ActionDispatch::IntegrationTest
-  attr_reader :draft_poll, :published_poll, :started_poll, :closed_poll, :archived_poll, :deleted_poll
+  attr_reader :drafted_poll, :published_poll, :started_poll, :closed_poll, :archived_poll, :deleted_poll
 
   setup do
-    @draft_poll = polls(:best_actress_draft)
+    @drafted_poll = polls(:best_actress_drafted)
     @published_poll = polls(:best_actor_published)
     @started_poll = polls(:best_singer_started)
     @closed_poll = polls(:best_movie_closed)
@@ -35,7 +35,7 @@ class Admin::PollsControllerTest < ActionDispatch::IntegrationTest
   test 'admin should get manage polls' do
     sign_in_as(:julia_roberts)
 
-    [draft_poll, published_poll, started_poll, closed_poll, archived_poll].each do |poll|
+    [drafted_poll, published_poll, started_poll, closed_poll, archived_poll].each do |poll|
       get admin_poll_path(poll)
       assert_response :success
     end

--- a/test/controllers/polls/votings_controller_test.rb
+++ b/test/controllers/polls/votings_controller_test.rb
@@ -98,7 +98,7 @@ class Polls::VotingsControllerTest < ActionDispatch::IntegrationTest
 
   test 'guest is redirected on #new to poll if poll is not started' do
     assert_raise(ActiveRecord::RecordNotFound) do
-      get poll_vote_path(polls(:best_actress_draft), token_value: 'not-relevant-for-this-test')
+      get poll_vote_path(polls(:best_actress_drafted), token_value: 'not-relevant-for-this-test')
     end
 
     assert_raise(ActiveRecord::RecordNotFound) do

--- a/test/controllers/polls/votings_controller_test.rb
+++ b/test/controllers/polls/votings_controller_test.rb
@@ -113,9 +113,9 @@ class Polls::VotingsControllerTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
 
-    assert_raise(ActiveRecord::RecordNotFound) do
-      get poll_vote_path(polls(:best_song_archived), token_value: 'BEST-SONG-TOKEN-1')
-    end
+    get poll_vote_path(polls(:best_song_archived), token_value: 'BEST-SONG-TOKEN-1')
+    follow_redirect!
+    assert_response :success
   end
 
   test 'guest cannot post #create for an unstarted poll, with valid token' do

--- a/test/controllers/polls_controller_test.rb
+++ b/test/controllers/polls_controller_test.rb
@@ -1,10 +1,10 @@
 require 'test_helper'
 
 class PollsControllerTest < ActionDispatch::IntegrationTest
-  attr_reader :draft_poll, :published_poll, :started_poll, :closed_poll, :archived_poll, :deleted_poll
+  attr_reader :drafted_poll, :published_poll, :started_poll, :closed_poll, :archived_poll, :deleted_poll
 
   setup do
-    @draft_poll = polls(:best_actress_draft)
+    @drafted_poll = polls(:best_actress_drafted)
     @published_poll = polls(:best_actor_published)
     @started_poll = polls(:best_singer_started)
     @closed_poll = polls(:best_movie_closed)
@@ -25,8 +25,8 @@ class PollsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  test 'not #get show draft, archived, deleted' do
-    [draft_poll, archived_poll, deleted_poll].each do |poll|
+  test 'not #get show drafted, archived, deleted' do
+    [drafted_poll, archived_poll, deleted_poll].each do |poll|
       assert_raises(ActiveRecord::RecordNotFound) { get poll_path(poll) }
     end
   end

--- a/test/controllers/polls_controller_test.rb
+++ b/test/controllers/polls_controller_test.rb
@@ -19,14 +19,14 @@ class PollsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test '#get show published, started, closed, archived' do
-    [published_poll, started_poll, closed_poll].each do |poll|
+    [published_poll, started_poll, closed_poll, archived_poll].each do |poll|
       get poll_path(poll)
       assert_response :success
     end
   end
 
   test 'not #get show drafted, archived, deleted' do
-    [drafted_poll, archived_poll, deleted_poll].each do |poll|
+    [drafted_poll, deleted_poll].each do |poll|
       assert_raises(ActiveRecord::RecordNotFound) { get poll_path(poll) }
     end
   end

--- a/test/fixtures/nominees.yml
+++ b/test/fixtures/nominees.yml
@@ -1,12 +1,12 @@
 best_actress_julia_roberts:
   custom_id: "best-actreess-julia"
-  poll: best_actress_draft
+  poll: best_actress_drafted
   name: "Julia Roberts"
   description: 'Pretty woman'
 
 best_actress_meryl_streep:
   custom_id: "best-actress-meryl-streep"
-  poll: best_actress_draft
+  poll: best_actress_drafted
   name: "Meryl Streep"
   description: "What is she wearing?"
 

--- a/test/fixtures/polls.yml
+++ b/test/fixtures/polls.yml
@@ -1,4 +1,4 @@
-best_actress_draft:
+best_actress_drafted:
   title: 'Best actress'
   custom_id: 'best-actress-poll'
   user: julia_roberts

--- a/test/fixtures/tokens.yml
+++ b/test/fixtures/tokens.yml
@@ -1,6 +1,6 @@
 best_actress_token_1:
   value: 'BEST-ACTRESS-TOKEN-1'
-  poll: best_actress_draft
+  poll: best_actress_drafted
 
 best_actor_token_1:
   value: 'BEST-ACTOR-TOKEN-1'

--- a/test/forms/admin/poll_state_change_form_test.rb
+++ b/test/forms/admin/poll_state_change_form_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class Admin::PollStateChangeFormTest < ActiveSupport::TestCase
   setup do
-    @draft_poll = polls(:best_actress_draft)
+    @drafted_poll = polls(:best_actress_drafted)
     @published_poll = polls(:best_actor_published)
     @started_poll = polls(:best_singer_started)
     @closed_poll = polls(:best_movie_closed)
@@ -11,14 +11,14 @@ class Admin::PollStateChangeFormTest < ActiveSupport::TestCase
   end
 
   test 'valid transitions' do
-    assert Admin::PollStateChangeForm.new(@draft_poll, next_state: :published).valid?
+    assert Admin::PollStateChangeForm.new(@drafted_poll, next_state: :published).valid?
     assert Admin::PollStateChangeForm.new(@published_poll, next_state: :started).valid?
     assert Admin::PollStateChangeForm.new(@started_poll, next_state: :closed).valid?
     assert Admin::PollStateChangeForm.new(@closed_poll, next_state: :archived).valid?
   end
 
   test 'invalid transitions' do
-    assert_not Admin::PollStateChangeForm.new(@draft_poll, next_state: :started).valid?
+    assert_not Admin::PollStateChangeForm.new(@drafted_poll, next_state: :started).valid?
     assert_not Admin::PollStateChangeForm.new(@published_poll, next_state: :closed).valid?
     assert_not Admin::PollStateChangeForm.new(@started_poll, next_state: :archived).valid?
   end

--- a/test/models/concerns/statable_test.rb
+++ b/test/models/concerns/statable_test.rb
@@ -1,13 +1,13 @@
 require 'test_helper'
 
 class StatableTest < ActiveSupport::TestCase
-  attr_reader :user, :draft_poll, :published_poll,
+  attr_reader :user, :drafted_poll, :published_poll,
               :started_poll, :closed_poll, :archived_poll,
               :deleted_poll
 
   setup do
     @user = users(:julia_roberts)
-    @draft_poll = polls(:best_actress_draft)
+    @drafted_poll = polls(:best_actress_drafted)
     @published_poll = polls(:best_actor_published)
     @started_poll = polls(:best_singer_started)
     @closed_poll = polls(:best_movie_closed)
@@ -16,23 +16,23 @@ class StatableTest < ActiveSupport::TestCase
   end
 
   test 'initial state' do
-    assert_equal :draft, Poll.new(title: 'Foo', user: user).state
+    assert_equal :drafted, Poll.new(title: 'Foo', user: user).state
   end
 
   test 'valid state transitions' do
-    assert @draft_poll.transit_to!(:published)
+    assert @drafted_poll.transit_to!(:published)
     assert @published_poll.transit_to!(:started)
     assert @started_poll.transit_to!(:closed)
     assert @closed_poll.transit_to!(:archived)
   end
 
   test 'valid state deletions' do
-    assert @draft_poll.transit_to!(:deleted)
+    assert @drafted_poll.transit_to!(:deleted)
     assert @published_poll.transit_to!(:deleted)
   end
 
   test '#editable?' do
-    assert draft_poll.editable?
+    assert drafted_poll.editable?
     assert published_poll.editable?
     assert_not started_poll.editable?
     assert_not closed_poll.editable?
@@ -41,7 +41,7 @@ class StatableTest < ActiveSupport::TestCase
   end
 
   test '#next_state' do
-    assert_equal :published, @draft_poll.next_state
+    assert_equal :published, @drafted_poll.next_state
     assert_equal :started, @published_poll.next_state
     assert_equal :closed, @started_poll.next_state
     assert_equal :archived, @closed_poll.next_state
@@ -51,7 +51,7 @@ class StatableTest < ActiveSupport::TestCase
   # publish
 
   test '#verified_user' do
-    poll = draft_poll
+    poll = drafted_poll
     poll.user.email_verified_at = nil
 
     assert_raise(ActiveRecord::RecordInvalid) { poll.transit_to!(:published) }
@@ -63,10 +63,10 @@ class StatableTest < ActiveSupport::TestCase
   end
 
   test 'scope, state, state check for publish!' do
-    poll = draft_poll
+    poll = drafted_poll
 
     assert_changes 'poll.published?', to: true do
-      assert_changes 'poll.state', from: :draft, to: :published do
+      assert_changes 'poll.state', from: :drafted, to: :published do
         poll.transit_to!(:published)
       end
     end
@@ -92,7 +92,7 @@ class StatableTest < ActiveSupport::TestCase
   end
 
   test '#start not startable' do
-    assert_raise(InvalidStateTransition) { draft_poll.transit_to!(:started) }
+    assert_raise(InvalidStateTransition) { drafted_poll.transit_to!(:started) }
     assert_raise(InvalidStateTransition) { closed_poll.transit_to!(:started) }
     assert_raise(InvalidStateTransition) { archived_poll.transit_to!(:started) }
     assert_raise(InvalidStateTransition) { deleted_poll.transit_to!(:started) }
@@ -111,7 +111,7 @@ class StatableTest < ActiveSupport::TestCase
   end
 
   test '#close! not closable' do
-    assert_raise(InvalidStateTransition) { draft_poll.transit_to!(:closed) }
+    assert_raise(InvalidStateTransition) { drafted_poll.transit_to!(:closed) }
     assert_raise(InvalidStateTransition) { published_poll.transit_to!(:closed) }
     assert_raise(InvalidStateTransition) { archived_poll.transit_to!(:closed) }
     assert_raise(InvalidStateTransition) { deleted_poll.transit_to!(:closed) }
@@ -130,7 +130,7 @@ class StatableTest < ActiveSupport::TestCase
   end
 
   test '#archive not archivable' do
-    assert_raise(InvalidStateTransition) { draft_poll.transit_to!(:archived) }
+    assert_raise(InvalidStateTransition) { drafted_poll.transit_to!(:archived) }
     assert_raise(InvalidStateTransition) { published_poll.transit_to!(:archived) }
     assert_raise(InvalidStateTransition) { started_poll.transit_to!(:archived) }
     assert_raise(InvalidStateTransition) { deleted_poll.transit_to!(:archived) }

--- a/test/system/polls_management_test.rb
+++ b/test/system/polls_management_test.rb
@@ -1,10 +1,10 @@
 require 'application_system_test_case'
 
 class PollsManagementTest < ApplicationSystemTestCase
-  attr_reader :draft_poll, :published_poll, :started_poll, :closed_poll, :archived_poll
+  attr_reader :drafted_poll, :published_poll, :started_poll, :closed_poll, :archived_poll
 
   setup do
-    @draft_poll = polls(:best_actress_draft)
+    @drafted_poll = polls(:best_actress_drafted)
     @published_poll = polls(:best_actor_published)
     @started_poll = polls(:best_singer_started)
     @closed_poll = polls(:best_movie_closed)
@@ -57,12 +57,12 @@ class PollsManagementTest < ApplicationSystemTestCase
 
   # show
 
-  test 'admin visits an drafted poll' do
+  test 'admin visits an drafteded poll' do
     sign_in_as(:julia_roberts)
 
     visit polls_path
 
-    click_on draft_poll.title
+    click_on drafted_poll.title
 
     assert_selector 'h1', text: 'Best actress'
     assert_selector 'p', text: 'Who is she?'
@@ -75,7 +75,7 @@ class PollsManagementTest < ApplicationSystemTestCase
     sign_in_as(:julia_roberts)
 
     visit polls_path
-    click_on draft_poll.title
+    click_on drafted_poll.title
     click_on 'Manage'
 
     assert_selector 'h1', text: 'Manage poll'
@@ -123,18 +123,18 @@ class PollsManagementTest < ApplicationSystemTestCase
     user = users(:julia_roberts)
     user.update(email_verified_at: nil)
 
-    visit admin_poll_path(draft_poll)
+    visit admin_poll_path(drafted_poll)
 
-    assert_selector '.poll-state', text: 'draft'
+    assert_selector '.poll-state', text: 'drafted'
     assert_text 'In order to publish this poll you need to verify your email first.'
     assert_selector ".poll-state-actions input[value='Publish poll']", count: 0
   end
 
-  test 'admin publishes a drafted a poll' do
+  test 'admin publishes a drafteded a poll' do
     sign_in_as(:julia_roberts)
 
-    visit admin_poll_path(draft_poll)
-    assert_selector '.poll-state', text: 'draft'
+    visit admin_poll_path(drafted_poll)
+    assert_selector '.poll-state', text: 'drafted'
 
     click_on 'Publish poll'
     assert_selector '.poll-state', text: 'published'

--- a/test/system/polls_visitor_test.rb
+++ b/test/system/polls_visitor_test.rb
@@ -2,7 +2,7 @@ require 'application_system_test_case'
 
 class PollsVisitorTest < ApplicationSystemTestCase
   setup do
-    @draft_poll = polls(:best_actress_draft)
+    @drafted_poll = polls(:best_actress_drafted)
     @published_poll = polls(:best_actor_published)
     @archived_poll = polls(:best_song_archived)
   end
@@ -37,7 +37,7 @@ class PollsVisitorTest < ApplicationSystemTestCase
 
   test 'guest cannot visit an unlisted poll' do
     sign_out
-    assert_no_visit_poll @draft_poll
+    assert_no_visit_poll @drafted_poll
   end
 
   private

--- a/test/system/polls_visitor_test.rb
+++ b/test/system/polls_visitor_test.rb
@@ -17,7 +17,6 @@ class PollsVisitorTest < ApplicationSystemTestCase
   end
 
   test 'guest can visit an archived poll' do
-    skip
     sign_out
 
     visit poll_path(@archived_poll)


### PR DESCRIPTION
Archived polls were no longer available anywhere.

The intention is to not see archived poll on the index page, but the user has the direct link to poll#show they should still see it.

