### PR TITLE
fix states for started and closed if poll is scheduled

### DIFF
--- a/app/models/concerns/statable.rb
+++ b/app/models/concerns/statable.rb
@@ -59,15 +59,15 @@ module Statable
     end
 
     def started?
-      return false if closed? || archived?
+      return false if archived?
 
-      started_at.present?
+      started_at&.past? && !closed?
     end
 
     def closed?
       return false if archived?
 
-      closed_at.present?
+      closed_at&.past?
     end
 
     def archived?


### PR DESCRIPTION
A poll is considered "scheduled" if started_at and closed_at are set. The new logic takes this into account, so that these columns may be present, but in the future.